### PR TITLE
add 'podcasts' stream support

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -11,6 +11,7 @@ def generate_random_id():
 
 STREAM_CHOICES = (
     ('BLOGGING', 'blogging'),
+    ('PODCASTS', 'podcasts'),
     ('LOGS', 'Daily Logs'),
 )
 


### PR DESCRIPTION
[On Zulip](https://recurse.zulipchat.com/#narrow/stream/blogging/topic/33.2E.20Role.20Models) folks discussed the possibility of Blaggregator reporting new podcasts. This is the start of that support, which seems pretty straightforward.

It looks like the `home/management/commands/crawlposts.py` job many need to be touched, or at least the prod server will need to start enqueueing that job. Thoughts from anyone who knows this codebase?